### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl"        : "6.*",
     "name"        : "RPi::Wiring::Pi",
+    "license"     : "GPL-3.0",
     "version"     : "2.25.0",
     "authors"     : [ "Aurelio Sanabria (Sufrostico) <sufrostico at gmail dot com>" ],
     "description" : "Perl 6 wrapper to the WiringPI, a wiring based Raspberry Pi library",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license