### PR TITLE
Declare SPI module.

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,12 +2,13 @@
     "perl"         : "6.c",
     "name"         : "RPi::Wiring::Pi",
     "license"      : "GPL-3.0",
-    "version"      : "2.25.0",
+    "version"      : "2.26.0",
     "authors"      : [ "Aurelio Sanabria (Sufrostico) <sufrostico at gmail dot com>" ],
     "description"  : "Perl 6 wrapper to the WiringPI, a wiring based Raspberry Pi library.",
     "test-depends" : [ "Test" ],
     "provides"     : {
-        "RPi::Wiring::Pi" : "lib/RPi/Wiring/Pi.pm6"
+        "RPi::Wiring::Pi"       : "lib/RPi/Wiring/Pi.pm6",
+        "RPi::Wiring::SPI"      : "lib/RPi/Wiring/SPI.pm6"
     },
     "support"      : {
         "source" : "git://github.com/sufrostico/perl6-wiringpi.git"

--- a/lib/RPi/Wiring/Pi.pm6
+++ b/lib/RPi/Wiring/Pi.pm6
@@ -374,7 +374,11 @@ sub waitForInterrupt (int32 , int32 ) returns int32 is native(LIB) is export {*}
     program) which runs concurrently with your main program and using the mutex
     mechanisms, safely pass variables between them.  ]
     #sub wiringPiISR (int32 pin, int32 edgeType, &callback ) returns int32 is native(LIB) is export {*};
-sub wiringPiISR (int32 , int32 , &callback ) returns int32 is native(LIB) is export {*};
+# wiringPiISR() does not work on current MoarVM, because this function starts a  new thread
+# and calls the callback from that thread. This causes an 'Unknown Thread ID'
+# panic.
+
+#sub wiringPiISR (int32 , int32 , &callback ()) returns int32 is native(LIB) is export {*};
 
 # Concurrent Processing (multi-threading) --------------------------------------
 


### PR DESCRIPTION
Otherwise one can't use it.
The other classes in there are left out, because they don't compile.